### PR TITLE
Load ReSpec over HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>Digital Publishing Accessibility Note</title>
     <meta charset='utf-8'>
-  <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
+  <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
   <script class='remove'>
       var respecConfig = {
           specStatus: "ED",


### PR DESCRIPTION
When accessing the github-hosted doc via HTTPS at https://w3c.github.io/dpub-accessibility/ , ReSpec won't load if served over HTTP (mixed content issue).
